### PR TITLE
feat: chat page UI — milestone 1

### DIFF
--- a/my-app/app/chat/ChatInput.tsx
+++ b/my-app/app/chat/ChatInput.tsx
@@ -1,0 +1,57 @@
+// Chat input bar at the bottom of the chat area.
+// Suggestion chip clicks will fill the input in Milestone 2.
+
+"use client"; // This component uses client-side state for the input value.
+
+import { useState } from "react";
+
+export default function ChatInput() {
+  const [value, setValue] = useState("");
+
+  return (
+    <div
+      style={{
+        padding: "16px 24px",
+        borderTop: "1px solid #e2e8f0",
+        background: "white",
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+      }}
+    >
+      <div style={{ display: "flex", gap: "10px" }}>
+        <input
+          type="text"
+          placeholder="Ask a question about your form..."
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          style={{
+            flex: 1,
+            padding: "12px 16px",
+            borderRadius: "12px",
+            border: "1px solid #e2e8f0",
+            fontSize: "14px",
+            outline: "none",
+          }}
+        />
+        <button
+          style={{
+            background: "#E8593C",
+            color: "white",
+            border: "none",
+            borderRadius: "12px",
+            padding: "12px 16px",
+            cursor: "pointer",
+            fontSize: "18px",
+          }}
+        >
+          ↑
+        </button>
+      </div>
+      <p style={{ fontSize: "12px", color: "#94a3b8", textAlign: "center" }}>
+        Responses are grounded in your document. Always verify important
+        details.
+      </p>
+    </div>
+  );
+}

--- a/my-app/app/chat/LanguageDropdown.tsx
+++ b/my-app/app/chat/LanguageDropdown.tsx
@@ -1,0 +1,88 @@
+// Language selector dropdown in the sidebar header.
+// Currently updates UI label only — translation wired in Milestone 2.
+
+"use client";
+
+import { useState } from "react";
+
+const languages = [
+  { code: "en", flag: "🇺🇸", label: "English" },
+  { code: "es", flag: "🇪🇸", label: "Español" },
+  { code: "zh", flag: "🇨🇳", label: "中文" },
+  { code: "ar", flag: "🇸🇦", label: "العربية" },
+  { code: "fr", flag: "🇫🇷", label: "Français" },
+];
+
+export default function LanguageDropdown() {
+  const [selected, setSelected] = useState(languages[0]);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ position: "relative", display: "inline-block" }}>
+      {/* Pill button */}
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+          padding: "6px 12px",
+          border: "1px solid #e2e8f0",
+          borderRadius: "20px",
+          background: "white",
+          fontSize: "13px",
+          cursor: "pointer",
+        }}
+      >
+        <span style={{ fontSize: "14px" }}>{selected.flag}</span>
+        <span>{selected.label}</span>
+        <span style={{ fontSize: "10px", color: "#94a3b8" }}>▾</span>
+      </button>
+
+      {/* Dropdown list */}
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            left: 0,
+            background: "white",
+            border: "1px solid #e2e8f0",
+            borderRadius: "12px",
+            overflow: "hidden",
+            zIndex: 10,
+            minWidth: "160px",
+          }}
+        >
+          {languages.map((lang) => (
+            <button
+              key={lang.code}
+              onClick={() => {
+                setSelected(lang);
+                setOpen(false);
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "10px",
+                width: "100%",
+                padding: "10px 14px",
+                border: "none",
+                background: selected.code === lang.code ? "#f8fafc" : "white",
+                fontSize: "13px",
+                cursor: "pointer",
+                textAlign: "left",
+              }}
+            >
+              <span style={{ fontSize: "16px" }}>{lang.flag}</span>
+              <span>{lang.label}</span>
+              {selected.code === lang.code && (
+                <span style={{ marginLeft: "auto", color: "#E8593C" }}>✓</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/my-app/app/chat/MessageBubble.tsx
+++ b/my-app/app/chat/MessageBubble.tsx
@@ -1,0 +1,106 @@
+// Chat message bubble component.
+// Renders AI and user messages differently based on the role prop.
+
+import { Message } from "./messages";
+
+export default function MessageBubble({ message }: { message: Message }) {
+  if (message.role === "user") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          marginBottom: "12px",
+        }}
+      >
+        <div
+          style={{
+            background: "#1C2B3A",
+            color: "white",
+            padding: "12px 16px",
+            borderRadius: "16px",
+            maxWidth: "75%",
+            fontSize: "14px",
+            lineHeight: "1.5",
+          }}
+        >
+          {message.text}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", gap: "10px", marginBottom: "12px" }}>
+      {/* Coral avatar */}
+      <div
+        style={{
+          width: "32px",
+          height: "32px",
+          borderRadius: "50%",
+          background: "#E8593C",
+          flexShrink: 0,
+        }}
+      />
+
+      <div
+        style={{
+          background: "white",
+          border: "1px solid #e2e8f0",
+          padding: "12px 16px",
+          borderRadius: "16px",
+          maxWidth: "75%",
+          fontSize: "14px",
+          lineHeight: "1.5",
+        }}
+      >
+        <p>{message.text}</p>
+
+        {/* Suggestion chips */}
+        {message.suggestions && (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "8px",
+              marginTop: "12px",
+            }}
+          >
+            {message.suggestions.map((s) => (
+              <button
+                key={s}
+                style={{
+                  padding: "8px 12px",
+                  border: "1px solid #e2e8f0",
+                  borderRadius: "8px",
+                  background: "white",
+                  fontSize: "13px",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Citation chip */}
+        {message.citation && (
+          <div
+            style={{
+              marginTop: "10px",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "6px",
+              fontSize: "12px",
+              color: "#E8593C",
+            }}
+          >
+            ◉ {message.citation}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/app/chat/messages.ts
+++ b/my-app/app/chat/messages.ts
@@ -1,0 +1,35 @@
+// Hardcoded message data and types for the chat thread.
+// Replace with live API responses in Milestone 2.
+
+export type Message = {
+  id: number;
+  role: "ai" | "user";
+  text: string;
+  suggestions?: string[];
+  citation?: string;
+};
+
+export const messages: Message[] = [
+  {
+    id: 1,
+    role: "ai",
+    text: "I've analyzed your form! This is Form I-765, the Application for Employment Authorization. I can help you understand what information you need and guide you through each section.",
+    suggestions: [
+      "What documents do I need?",
+      "How much is the filing fee?",
+      "What goes in Part 2?",
+      "When should I submit this?",
+    ],
+  },
+  {
+    id: 2,
+    role: "user",
+    text: "What documents do I need?",
+  },
+  {
+    id: 3,
+    role: "ai",
+    text: "In Part 2, Question 3, you'll need to provide your full legal name as it appears on your passport or birth certificate. This should match your supporting documents exactly.",
+    citation: "Part 2, Line 3.a–3.c",
+  },
+];

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,5 +1,6 @@
 import { messages } from "./messages";
 import MessageBubble from "./MessageBubble";
+import ChatInput from "./ChatInput";
 
 export default function ChatPage() {
   return (
@@ -23,6 +24,7 @@ export default function ChatPage() {
             <MessageBubble key={m.id} message={m} />
           ))}
         </div>
+        <ChatInput />
       </div>
     </div>
   );

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,0 +1,8 @@
+export default function ChatPage() {
+  return (
+    <div>
+      <h1>Chat Page</h1>
+      <p>Coming Soon!</p>
+    </div>
+  );
+}

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,3 +1,6 @@
+import { messages } from "./messages";
+import MessageBubble from "./MessageBubble";
+
 export default function ChatPage() {
   return (
     <div style={{ display: "flex", height: "100vh" }}>
@@ -5,6 +8,7 @@ export default function ChatPage() {
       <div style={{ width: "260px", background: "#e2e8f0", flexShrink: 0 }}>
         <p>Sidebar</p>
       </div>
+
       {/* Chat area */}
       <div
         style={{
@@ -14,7 +18,11 @@ export default function ChatPage() {
           flexDirection: "column",
         }}
       >
-        <p>Chat area</p>
+        <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
+          {messages.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,8 +1,21 @@
 export default function ChatPage() {
   return (
-    <div>
-      <h1>Chat Page</h1>
-      <p>Coming Soon!</p>
+    <div style={{ display: "flex", height: "100vh" }}>
+      {/* Sidebar */}
+      <div style={{ width: "260px", background: "#e2e8f0", flexShrink: 0 }}>
+        <p>Sidebar</p>
+      </div>
+      {/* Chat area */}
+      <div
+        style={{
+          flex: 1,
+          background: "#f8fafc",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <p>Chat area</p>
+      </div>
     </div>
   );
 }

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,13 +1,21 @@
 import { messages } from "./messages";
 import MessageBubble from "./MessageBubble";
 import ChatInput from "./ChatInput";
+import LanguageDropdown from "./LanguageDropdown";
 
 export default function ChatPage() {
   return (
     <div style={{ display: "flex", height: "100vh" }}>
       {/* Sidebar */}
-      <div style={{ width: "260px", background: "#e2e8f0", flexShrink: 0 }}>
-        <p>Sidebar</p>
+      <div
+        style={{
+          width: "260px",
+          background: "#e2e8f0",
+          flexShrink: 0,
+          padding: "16px",
+        }}
+      >
+        <LanguageDropdown />
       </div>
 
       {/* Chat area */}

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -1,65 +1,10 @@
-import Image from "next/image";
+import Link from "next/link";
 
-export default function Home() {
+export default function HomePage() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+    <div>
+      <p>Upload page - coming soon!</p>
+      <Link href="/chat">Go to chat</Link>
     </div>
   );
 }


### PR DESCRIPTION
This is a **static, fully navigable chat UI** with hardcoded data. There are no API calls, all content is a placeholder, but it is ready to be wired to the backend in Milestone 2.

**These are the big changes:**
1. /chat route with three-column layout shell (sidebar + chat area)
2. Hardcoded messages data and TypeScript types (messages.ts)
3. MessageBubble component — handles AI bubbles (with suggestion chips and citation chip) and user bubbles
4. ChatInput bar with send button and disclaimer footer
5. LanguageDropdown — 5 languages, updates label on select

**Limitations(will be resolved in the next PR):** 
1. No project colors or typography yet: will be updated
2. Upload page (/) in progress
3. No API calls, translation, or state persistence 

**How to test:** 
npm run dev

<img width="1426" height="801" alt="Screenshot 2026-04-23 at 2 00 49 PM" src="https://github.com/user-attachments/assets/0d563d19-4b16-4fe1-8e3a-11b4389d0aad" />