### PR TITLE
fix: make chat input and language dropdown backward compatible

### DIFF
--- a/my-app/app/chat/ChatInput.tsx
+++ b/my-app/app/chat/ChatInput.tsx
@@ -1,31 +1,38 @@
 // Chat input bar at the bottom of the chat area.
 "use client";
 
+import { useState } from "react";
+
 type ChatInputProps = {
-  value: string;
-  onChange: (value: string) => void;
-  onSend: () => void;
+  value?: string;
+  onChange?: (value: string) => void;
+  onSend?: () => void;
 };
 
 export default function ChatInput({ value, onChange, onSend }: ChatInputProps) {
+  const [localValue, setLocalValue] = useState("");
+  const resolvedValue = value ?? localValue;
+  const resolvedOnChange = onChange ?? setLocalValue;
+  const resolvedOnSend = onSend ?? (() => {});
+
   return (
     <div className="border-t border-[#efe6df] bg-white px-6 py-4">
       <div className="flex items-center gap-3">
         <input
           type="text"
           placeholder="Ask a question about your form..."
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
+          value={resolvedValue}
+          onChange={(e) => resolvedOnChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              onSend();
+              resolvedOnSend();
             }
           }}
           className="flex-1 rounded-2xl border border-[#efe6df] bg-[#f8f5f1] px-4 py-3 text-sm text-[var(--navy)] outline-none transition focus:border-[#d6c8bd]"
         />
         <button
-          onClick={onSend}
+          onClick={resolvedOnSend}
           className="rounded-2xl bg-[var(--coral)] px-4 py-3 text-sm font-medium text-white transition hover:opacity-95"
           aria-label="Send question"
         >

--- a/my-app/app/chat/LanguageDropdown.tsx
+++ b/my-app/app/chat/LanguageDropdown.tsx
@@ -19,8 +19,8 @@ export const languages: LanguageOption[] = [
 ];
 
 type LanguageDropdownProps = {
-  selected: LanguageOption;
-  onSelect: (language: LanguageOption) => void;
+  selected?: LanguageOption;
+  onSelect?: (language: LanguageOption) => void;
 };
 
 export default function LanguageDropdown({
@@ -28,6 +28,9 @@ export default function LanguageDropdown({
   onSelect,
 }: LanguageDropdownProps) {
   const [open, setOpen] = useState(false);
+  const [localSelected, setLocalSelected] = useState<LanguageOption>(languages[0]);
+  const resolvedSelected = selected ?? localSelected;
+  const resolvedOnSelect = onSelect ?? setLocalSelected;
 
   return (
     <div className="relative inline-block">
@@ -36,7 +39,7 @@ export default function LanguageDropdown({
         className="inline-flex items-center gap-2 rounded-full border border-[#e8ddd3] bg-white px-3 py-1.5 text-xs font-medium text-[var(--navy)]"
       >
         <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--coral)]" />
-        <span>{selected.label}</span>
+        <span>{resolvedSelected.label}</span>
         <span className="text-[10px] text-gray-400">v</span>
       </button>
 
@@ -46,11 +49,11 @@ export default function LanguageDropdown({
             <button
               key={lang.code}
               onClick={() => {
-                onSelect(lang);
+                resolvedOnSelect(lang);
                 setOpen(false);
               }}
               className={`flex w-full items-center px-3 py-2 text-left text-sm ${
-                selected.code === lang.code
+                resolvedSelected.code === lang.code
                   ? "bg-[#faf7f3] text-[var(--navy)]"
                   : "bg-white text-gray-600"
               }`}


### PR DESCRIPTION
Allow ChatInput and LanguageDropdown to run with internal fallback state when page-level props are not provided, so older chat page usage on main compiles cleanly.

This is a bug fix