### PR TITLE
feat(chat): wire /chat to streaming OpenAI replies (Vercel AI SDK v6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,212 @@
-# spr26-Team-10
+# spr26-Team-10 — formly.ai
 
-Eva Tom
-Ruba Ahmed
+Eva Tom | Ruba Ahmed | Eric He | Tyler Huang | Stephen Makuol
+
+
+**formly.ai** is a friendly assistant that helps
+people understand U.S. government forms in their preferred language.
+
+The current prototype lets a user pick a language, ask questions in a chat
+panel, and get a streaming AI reply grounded in a (currently mocked) form. The
+MVP is built on Next.js 16 + React 19 + the Vercel AI SDK v6 with OpenAI as the
+model provider.
+
+**Team:** Eva Tom, Ruba Ahmed, Eric He, Tyler Huang, Stephen Makuol
+
+---
+
+## Repository layout
+
+```
+spr26-Team-10/
+├── README.md                          ← you are here
+├── ruba-test.py / stephen_test.py     ← legacy stubs, ignore
+└── my-app/                            ← the Next.js app (everything lives here)
+    ├── README.md                      ← Next-specific setup notes
+    ├── AGENTS.md                      ← guidance for AI coding agents
+    ├── CLAUDE.md                      ← imports AGENTS.md
+    ├── package.json                   ← deps: next 16, react 19, ai v6,
+    │                                    @ai-sdk/openai, @ai-sdk/react,
+    │                                    @supabase/supabase-js
+    ├── next.config.ts / tsconfig.json / eslint.config.mjs / postcss.config.mjs
+    ├── .env.local.example             ← template; copy to .env.local
+    ├── .gitignore                     ← ignores .env* except the example
+    ├── app/                           ← Next.js App Router
+    │   ├── layout.tsx                 ← root <html>/<body>, DM Sans font
+    │   ├── globals.css                ← Tailwind v4 + theme tokens
+    │   ├── page.tsx                   ← landing / upload / OCR-review steps
+    │   ├── api/
+    │   │   └── chat/
+    │   │       └── route.ts           ← edge POST /api/chat → OpenAI stream
+    │   └── chat/
+    │       ├── page.tsx               ← /chat — three-pane chat shell
+    │       ├── ChatInput.tsx          ← bottom input bar (loading-aware)
+    │       ├── MessageBubble.tsx      ← AI/user bubble, suggestions,
+    │       │                            annotations, citation chip
+    │       ├── LanguageDropdown.tsx   ← en / es / zh / ar / fr selector
+    │       └── messages.ts            ← seed UIMessage[] + messageMeta map
+    ├── lib/
+    │   └── supabaseClient.ts          ← currently empty (see TODO below)
+    └── public/
+        ├── formly_nobackground.png    ← brand logo
+        └── file.svg / globe.svg / next.svg / vercel.svg / window.svg
+```
+
+---
+
+## Data flow / architecture
+
+### High-level flow
+
+```mermaid
+flowchart LR
+    User([User]) -->|opens| Home["/ (page.tsx)"]
+    Home -->|"upload + review (mocked OCR)"| Chat["/chat (page.tsx)"]
+    Chat -->|"useChat hook"| Hook[/"@ai-sdk/react useChat"/]
+    Hook -->|"POST messages + language"| Route["/api/chat (route.ts)"]
+    Route -->|"streamText"| OpenAI[("OpenAI gpt-4o-mini")]
+    OpenAI -->|"streaming tokens"| Route
+    Route -->|"UI message stream (SSE)"| Hook
+    Hook -->|"appends parts to assistant message"| Chat
+    Chat -->|"renders via MessageBubble"| User
+```
+
+### Chat request lifecycle
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as chat/page.tsx
+    participant H as useChat (client)
+    participant R as /api/chat route.ts (edge)
+    participant O as OpenAI
+
+    U->>P: types question + clicks Send
+    P->>H: sendMessage({ text }, { body: { language } })
+    H->>R: POST { messages: UIMessage[], language }
+    R->>R: convertToModelMessages(messages)
+    R->>R: buildSystemPrompt(language)
+    R->>O: streamText({ model: gpt-4o-mini, system, messages })
+    O-->>R: token stream
+    R-->>H: UI message stream (toUIMessageStreamResponse)
+    H-->>P: status: submitted → streaming → ready
+    P-->>U: typing bubble → streaming text → final reply
+```
+
+### Component responsibilities
+
+| File                              | Responsibility                                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `app/page.tsx`                    | Landing page. Two-step upload → OCR-review wizard. (OCR text is currently hardcoded.)                       |
+| `app/chat/page.tsx`               | Chat shell. Owns the `useChat` hook, language state, layout, typing bubble, and error-with-Retry chip.      |
+| `app/chat/ChatInput.tsx`          | Bottom input bar. Disables itself + swaps placeholder/label while `isLoading`. Enter-to-send.               |
+| `app/chat/MessageBubble.tsx`      | Renders one `UIMessage`. Joins text parts; looks up suggestions / annotations / citation in `messageMeta`.  |
+| `app/chat/LanguageDropdown.tsx`   | Pill-style selector for `en` / `es` / `zh` / `ar` / `fr`. Triggers `dir="rtl"` for Arabic.                  |
+| `app/chat/messages.ts`            | Exports `seedMessages: UIMessage[]` (for demo polish) and `messageMeta` keyed by id (chips / annotations).  |
+| `app/api/chat/route.ts`           | Edge runtime POST. Builds system prompt with target language, streams `gpt-4o-mini` via the AI SDK.         |
+| `lib/supabaseClient.ts`           | **Empty.** Will hold the Supabase client when the document-grounding workstream lands.                      |
+
+### Language handling
+
+The dropdown's selected language code is sent **per request** as a `body` field
+on `sendMessage`. The route handler maps it to a human-readable name and bakes
+it into the system prompt (e.g. *"Reply in Spanish, regardless of the language
+of the user's question"*). This means switching the dropdown takes effect on
+the next message without re-creating the `useChat` hook.
+
+The chat **chrome** (sidebar headings, subtitle, etc.) is independently
+re-labeled in `app/chat/page.tsx` from a static `uiLabels` map.
+
+### Out of scope (TODO)
+
+- **Supabase / document grounding** — `lib/supabaseClient.ts` is empty, the
+  OCR-review step on the home page uses hardcoded I-765 text, and the route
+  handler does not pull document context from a database. A separate
+  workstream owns this; it will plug into the system prompt (or a tool call)
+  once the schema and OCR pipeline land.
+- **Conversation persistence** — refreshing `/chat` resets to the seed thread.
+- **Auth** — none yet; chat is fully anonymous.
+- **AI-generated suggestion chips / annotations / citations** — the live model
+  returns plain text. The rich UI elements only render for the seed messages
+  via `messageMeta`. Generating them from real form context will need a
+  structured-output pass once document grounding exists.
+
+---
+
+## Runbook
+
+### Prerequisites
+
+- Node.js 18+ (the AI SDK requires it; Next.js 16 wants 18.18+).
+- npm 10+ (or another package manager — examples below assume npm).
+- An OpenAI API key with access to `gpt-4o-mini`. Get one at
+  [platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+
+### First-time setup
+
+```bash
+git clone git@github.com:StanfordCS194/spr26-Team-10.git
+cd spr26-Team-10/my-app
+
+# install deps (will pull next 16, react 19, ai v6, etc.)
+npm install
+
+# create your local env file from the template
+cp .env.local.example .env.local
+# then edit .env.local and set:
+#   OPENAI_API_KEY=sk-...
+```
+
+> `.env.local` is gitignored. `.env.local.example` is committed.
+
+### Local development
+
+```bash
+cd my-app
+npm run dev
+```
+
+Then open http://localhost:3000.
+
+- `/` — upload + OCR-review wizard. Pick any file, click "Upload and continue",
+  then "Confirm and ask questions" to land on `/chat`.
+- `/chat` — type a question and watch the reply stream. Switch the language
+  dropdown and ask another question to see the response come back in the new
+  language.
+
+### Common scripts
+
+```bash
+cd my-app
+
+npm run dev         # start the dev server (Turbopack)
+npm run build       # production build; also runs the TS checker
+npm run start       # serve the production build
+npm run lint        # ESLint (eslint.config.mjs)
+npx tsc --noEmit    # type-check without emitting
+```
+
+### Deployment
+
+The app is a stock Next.js 16 project, so any Next-compatible host works
+(Vercel is the easiest path). The only required server-side env var is
+`OPENAI_API_KEY`. Once Supabase lands, expect to add `NEXT_PUBLIC_SUPABASE_URL`
+and `NEXT_PUBLIC_SUPABASE_ANON_KEY` (and possibly a service-role key for the
+route handler).
+
+### Troubleshooting
+
+| Symptom                                        | Likely cause / fix                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Error chip + Retry on every send               | `OPENAI_API_KEY` missing / invalid in `my-app/.env.local`. Restart `npm run dev` after editing.   |
+| `Module not found: ai` / `@ai-sdk/openai`      | Run `npm install` inside `my-app/` — the lockfile pins AI SDK v6.                                 |
+| TS errors mentioning `Message` / old shape     | A consumer is still on the pre-v6 message shape. Use `UIMessage` from `ai` and read `parts`.      |
+| Reply comes back in the wrong language         | Make sure you sent a new message **after** changing the dropdown — language is per-request.       |
+| `/chat` typing bubble never goes away          | Check the browser network tab — the SSE stream from `/api/chat` may be blocked by an extension.   |
+
+### AI agent guidance
+
+If you're using Cursor, Claude Code, or another coding agent, also read
+[`my-app/AGENTS.md`](my-app/AGENTS.md). Next.js 16 has breaking changes from
+older versions, and the file points agents at `node_modules/next/dist/docs/`
+for current API references.

--- a/my-app/.env.local.example
+++ b/my-app/.env.local.example
@@ -1,0 +1,6 @@
+# Copy this file to `.env.local` and fill in your secrets.
+# `.env.local` is gitignored.
+
+# OpenAI API key — used by the streaming chat at /chat (app/api/chat/route.ts).
+# Get one at https://platform.openai.com/api-keys
+OPENAI_API_KEY=

--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/my-app/README.md
+++ b/my-app/README.md
@@ -1,5 +1,16 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Setup
+
+Copy the example env file and fill in your OpenAI key (used by the streaming chat at `/chat`):
+
+```bash
+cp .env.local.example .env.local
+# then edit .env.local and set OPENAI_API_KEY=sk-...
+```
+
+Get an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+
 ## Getting Started
 
 First, run the development server:

--- a/my-app/app/api/chat/route.ts
+++ b/my-app/app/api/chat/route.ts
@@ -1,0 +1,49 @@
+import { openai } from "@ai-sdk/openai";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
+
+export const runtime = "edge";
+
+export const maxDuration = 30;
+
+type LanguageCode = "en" | "es" | "zh" | "ar" | "fr";
+
+const LANGUAGE_NAMES: Record<LanguageCode, string> = {
+  en: "English",
+  es: "Spanish",
+  zh: "Chinese (Simplified)",
+  ar: "Arabic",
+  fr: "French",
+};
+
+function buildSystemPrompt(language: LanguageCode): string {
+  const languageName = LANGUAGE_NAMES[language] ?? "English";
+
+  return [
+    "You are formly.ai, a friendly assistant that helps people understand U.S. government forms (immigration, tax, benefits, etc.).",
+    "Explain in plain language. Be concrete: name the part/line/field of the form when you can.",
+    "If you do not know something or the user has not provided enough context, say so honestly and suggest what to check.",
+    "Do not give legal advice or guarantee outcomes; recommend consulting a qualified professional for legal questions.",
+    `Reply in ${languageName}, regardless of the language of the user's question. Keep responses concise (a short paragraph or a brief list).`,
+  ].join(" ");
+}
+
+export async function POST(req: Request) {
+  const { messages, language } = (await req.json()) as {
+    messages: UIMessage[];
+    language?: LanguageCode;
+  };
+
+  const result = streamText({
+    model: openai("gpt-4o-mini"),
+    system: buildSystemPrompt(language ?? "en"),
+    messages: await convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse({
+    onError: (error) => {
+      if (error instanceof Error) return error.message;
+      if (typeof error === "string") return error;
+      return "Something went wrong while generating a response.";
+    },
+  });
+}

--- a/my-app/app/chat/ChatInput.tsx
+++ b/my-app/app/chat/ChatInput.tsx
@@ -1,4 +1,3 @@
-// Chat input bar at the bottom of the chat area.
 "use client";
 
 import { useState } from "react";
@@ -7,36 +6,50 @@ type ChatInputProps = {
   value?: string;
   onChange?: (value: string) => void;
   onSend?: () => void;
+  isLoading?: boolean;
 };
 
-export default function ChatInput({ value, onChange, onSend }: ChatInputProps) {
+export default function ChatInput({
+  value,
+  onChange,
+  onSend,
+  isLoading = false,
+}: ChatInputProps) {
   const [localValue, setLocalValue] = useState("");
   const resolvedValue = value ?? localValue;
   const resolvedOnChange = onChange ?? setLocalValue;
   const resolvedOnSend = onSend ?? (() => {});
+
+  const trimmedEmpty = resolvedValue.trim().length === 0;
+  const sendDisabled = isLoading || trimmedEmpty;
 
   return (
     <div className="border-t border-[#efe6df] bg-white px-6 py-4">
       <div className="flex items-center gap-3">
         <input
           type="text"
-          placeholder="Ask a question about your form..."
+          placeholder={
+            isLoading ? "Waiting for response..." : "Ask a question about your form..."
+          }
           value={resolvedValue}
           onChange={(e) => resolvedOnChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              resolvedOnSend();
+              if (!sendDisabled) resolvedOnSend();
             }
           }}
-          className="flex-1 rounded-2xl border border-[#efe6df] bg-[#f8f5f1] px-4 py-3 text-sm text-[var(--navy)] outline-none transition focus:border-[#d6c8bd]"
+          disabled={isLoading}
+          aria-busy={isLoading}
+          className="flex-1 rounded-2xl border border-[#efe6df] bg-[#f8f5f1] px-4 py-3 text-sm text-[var(--navy)] outline-none transition focus:border-[#d6c8bd] disabled:cursor-not-allowed disabled:opacity-60"
         />
         <button
           onClick={resolvedOnSend}
-          className="rounded-2xl bg-[var(--coral)] px-4 py-3 text-sm font-medium text-white transition hover:opacity-95"
+          disabled={sendDisabled}
+          className="rounded-2xl bg-[var(--coral)] px-4 py-3 text-sm font-medium text-white transition enabled:hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Send question"
         >
-          Send
+          {isLoading ? "..." : "Send"}
         </button>
       </div>
       <p className="mt-2 text-center text-xs text-gray-500">

--- a/my-app/app/chat/MessageBubble.tsx
+++ b/my-app/app/chat/MessageBubble.tsx
@@ -1,20 +1,28 @@
-// Chat message bubble component.
-// Renders AI and user messages differently based on the role prop.
+import type { UIMessage } from "ai";
+import { messageMeta } from "./messages";
 
-import { Message } from "./messages";
+function getText(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
 
 export default function MessageBubble({
   message,
   onSuggestionClick,
 }: {
-  message: Message;
+  message: UIMessage;
   onSuggestionClick?: (value: string) => void;
 }) {
+  const text = getText(message);
+  const meta = messageMeta[message.id];
+
   if (message.role === "user") {
     return (
       <div className="mb-3 flex justify-end">
         <div className="max-w-[75%] rounded-2xl bg-[var(--navy)] px-5 py-4 text-sm leading-6 text-white shadow-sm">
-          <p>{message.text}</p>
+          <p className="whitespace-pre-wrap">{text}</p>
         </div>
       </div>
     );
@@ -22,16 +30,14 @@ export default function MessageBubble({
 
   return (
     <div className="mb-3 flex gap-3">
-      {/* Coral avatar */}
       <div className="mt-2 h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--coral)]" />
 
       <div className="max-w-[78%] rounded-2xl border border-[#efe6df] bg-white px-4 py-4 text-sm leading-6 text-[var(--navy)] shadow-sm">
-        <p>{message.text}</p>
+        <p className="whitespace-pre-wrap">{text}</p>
 
-        {/* Suggestion chips */}
-        {message.suggestions && (
+        {meta?.suggestions && (
           <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {message.suggestions.map((s) => (
+            {meta.suggestions.map((s) => (
               <button
                 key={s}
                 onClick={() => onSuggestionClick?.(s)}
@@ -43,9 +49,9 @@ export default function MessageBubble({
           </div>
         )}
 
-        {message.annotations && (
+        {meta?.annotations && (
           <div className="mt-4 space-y-2">
-            {message.annotations.map((annotation) => (
+            {meta.annotations.map((annotation) => (
               <div
                 key={annotation.title}
                 className="rounded-xl border border-[#efe3be] bg-[#fff9e8] px-3 py-2"
@@ -56,16 +62,17 @@ export default function MessageBubble({
                 <p className="mt-1 text-[13px] font-semibold text-[var(--navy)]">
                   {annotation.title}
                 </p>
-                <p className="mt-0.5 text-xs text-[#7a6a45]">{annotation.detail}</p>
+                <p className="mt-0.5 text-xs text-[#7a6a45]">
+                  {annotation.detail}
+                </p>
               </div>
             ))}
           </div>
         )}
 
-        {/* Citation chip */}
-        {message.citation && (
+        {meta?.citation && (
           <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-[#f6d4cb] bg-[#fff5f2] px-3 py-1 text-xs text-[var(--coral)]">
-            Source: {message.citation}
+            Source: {meta.citation}
           </div>
         )}
       </div>

--- a/my-app/app/chat/messages.ts
+++ b/my-app/app/chat/messages.ts
@@ -1,10 +1,6 @@
-// Hardcoded message data and types for the chat thread.
-// Replace with live API responses in Milestone 2.
+import type { UIMessage } from "ai";
 
-export type Message = {
-  id: number;
-  role: "ai" | "user";
-  text: string;
+export type MessageMeta = {
   suggestions?: string[];
   citation?: string;
   annotations?: {
@@ -14,11 +10,41 @@ export type Message = {
   }[];
 };
 
-export const messages: Message[] = [
+export const seedMessages: UIMessage[] = [
   {
-    id: 1,
-    role: "ai",
-    text: "I've analyzed your form! This is Form I-765, the Application for Employment Authorization. I can help you understand what information you need and guide you through each section.",
+    id: "seed-1",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        text: "I've analyzed your form! This is Form I-765, the Application for Employment Authorization. I can help you understand what information you need and guide you through each section.",
+      },
+    ],
+  },
+  {
+    id: "seed-2",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        text: "What documents do I need?",
+      },
+    ],
+  },
+  {
+    id: "seed-3",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        text: "In Part 2, Question 3, you'll need to provide your full legal name as it appears on your passport or birth certificate. This should match your supporting documents exactly. If you've changed your name, include documentation of the name change.",
+      },
+    ],
+  },
+];
+
+export const messageMeta: Record<string, MessageMeta> = {
+  "seed-1": {
     suggestions: [
       "What documents do I need?",
       "How much is the filing fee?",
@@ -26,15 +52,7 @@ export const messages: Message[] = [
       "When should I submit this?",
     ],
   },
-  {
-    id: 2,
-    role: "user",
-    text: "What documents do I need?",
-  },
-  {
-    id: 3,
-    role: "ai",
-    text: "In Part 2, Question 3, you'll need to provide your full legal name as it appears on your passport or birth certificate. This should match your supporting documents exactly. If you've changed your name, include documentation of the name change.",
+  "seed-3": {
     annotations: [
       {
         tag: "Family Name",
@@ -49,4 +67,4 @@ export const messages: Message[] = [
     ],
     citation: "Part 2, Line 3.a–3.c",
   },
-];
+};

--- a/my-app/app/chat/page.tsx
+++ b/my-app/app/chat/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { messages, Message } from "./messages";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import { seedMessages } from "./messages";
 import MessageBubble from "./MessageBubble";
 import ChatInput from "./ChatInput";
 import LanguageDropdown, {
@@ -71,7 +73,6 @@ const uiLabels: Record<
 };
 
 export default function ChatPage() {
-  const [thread, setThread] = useState<Message[]>(messages);
   const [inputValue, setInputValue] = useState("");
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageOption>(
     languages[0],
@@ -79,31 +80,20 @@ export default function ChatPage() {
   const labels = uiLabels[selectedLanguage.code];
   const isRtl = selectedLanguage.code === "ar";
 
-  const nextId = useMemo(
-    () => thread.reduce((maxId, message) => Math.max(maxId, message.id), 0) + 1,
-    [thread],
-  );
+  const { messages, sendMessage, status, error, regenerate } = useChat({
+    messages: seedMessages,
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
 
-  const sendMessage = () => {
+  const isBusy = status === "submitted" || status === "streaming";
+
+  const handleSend = () => {
     const text = inputValue.trim();
-    if (!text) {
-      return;
-    }
-
-    const userMessage: Message = {
-      id: nextId,
-      role: "user",
-      text,
-    };
-
-    const aiReply: Message = {
-      id: nextId + 1,
-      role: "ai",
-      text: "Thanks for your question. I can help explain this section and point to the exact field in your form.",
-      citation: "Part 2, Line 3.a-3.c",
-    };
-
-    setThread((prev) => [...prev, userMessage, aiReply]);
+    if (!text || isBusy) return;
+    sendMessage(
+      { text },
+      { body: { language: selectedLanguage.code } },
+    );
     setInputValue("");
   };
 
@@ -218,19 +208,56 @@ export default function ChatPage() {
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col bg-[#F8F5F1]">
-          <div className="flex-1 overflow-y-auto p-4 sm:p-6">
-            {thread.map((m) => (
+          <div
+            className="flex-1 overflow-y-auto p-4 sm:p-6"
+            aria-busy={isBusy}
+            aria-live="polite"
+          >
+            {messages.map((m) => (
               <MessageBubble
                 key={m.id}
                 message={m}
                 onSuggestionClick={(value) => setInputValue(value)}
               />
             ))}
+
+            {status === "submitted" && (
+              <div className="mb-3 flex gap-3" aria-label="Assistant is typing">
+                <div className="mt-2 h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--coral)]" />
+                <div className="rounded-2xl border border-[#efe6df] bg-white px-4 py-3 text-sm text-gray-400 shadow-sm">
+                  <span className="inline-flex gap-1">
+                    <span className="animate-pulse">.</span>
+                    <span className="animate-pulse [animation-delay:150ms]">
+                      .
+                    </span>
+                    <span className="animate-pulse [animation-delay:300ms]">
+                      .
+                    </span>
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className="mb-3 flex flex-col items-start gap-2">
+                <div className="rounded-2xl border border-[#f6d4cb] bg-[#fff5f2] px-4 py-3 text-sm text-[var(--coral)] shadow-sm">
+                  Something went wrong. Please try again.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => regenerate()}
+                  className="rounded-full border border-[#f6d4cb] bg-white px-3 py-1 text-xs font-medium text-[var(--coral)] transition hover:bg-[#fff5f2]"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
           </div>
           <ChatInput
             value={inputValue}
             onChange={setInputValue}
-            onSend={sendMessage}
+            onSend={handleSend}
+            isLoading={isBusy}
           />
         </div>
       </section>

--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -8,7 +8,10 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.53",
+        "@ai-sdk/react": "^3.0.170",
         "@supabase/supabase-js": "^2.104.0",
+        "ai": "^6.0.168",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -22,6 +25,86 @@
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.170",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.170.tgz",
+      "integrity": "sha512-YUDn+mK0c8iUz14rCBf1A0zg6SV5b5aSVUz+azF1bdBd1SFXVI19dKYR+PQSpZY+0+z+zs252AAsacUqiO98Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.23",
+        "ai": "6.0.168",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1241,11 +1324,26 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -2248,6 +2346,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2269,6 +2376,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2890,6 +3015,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3562,6 +3696,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4567,6 +4710,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6169,6 +6318,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
@@ -6188,6 +6350,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -6526,6 +6700,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6686,7 +6869,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.53",
+    "@ai-sdk/react": "^3.0.170",
     "@supabase/supabase-js": "^2.104.0",
+    "ai": "^6.0.168",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary

Replace the canned echo reply on `/chat` with real, streaming OpenAI completions
through the Vercel AI SDK v6. Replies stream token-by-token and respect the
language picked in the sidebar dropdown.

- New edge route `app/api/chat/route.ts` builds a formly.ai system prompt,
  pins the response language (en / es / zh / ar / fr), and streams `gpt-4o-mini`
  via `streamText` + `toUIMessageStreamResponse()`.
- `app/chat/page.tsx` now uses `useChat` from `@ai-sdk/react` with
  `DefaultChatTransport`. Language is sent per-request via the second
  argument to `sendMessage`, so changing the dropdown takes effect on the
  next message without re-creating the hook.
- Seed thread is preserved: `messages.ts` exports `seedMessages: UIMessage[]`
  and a separate `messageMeta` map for the rich extras (suggestion chips,
  annotations, citation chip). Live model replies render as plain text
  bubbles since they have no `messageMeta` entry.
- `MessageBubble.tsx` reads text by joining `parts` (the v6 streaming model)
  and looks up extras in `messageMeta`.
- `ChatInput.tsx` accepts an `isLoading` prop, disables itself and swaps
  the placeholder/label while a response is streaming.
- Typing-bubble placeholder shown while `status === 'submitted'`; on error,
  a coral chip with a Retry button calls `regenerate()`. Thread region is
  marked `aria-busy` / `aria-live="polite"`.

## Setup

```bash
cp my-app/.env.local.example my-app/.env.local
# edit my-app/.env.local and set OPENAI_API_KEY=sk-...
cd my-app && npm install && npm run dev
```


### Out of scope (still TODO)
- Supabase integration is intentionally not wired up in this PR — `lib/supabaseClient.ts` is still empty, the home-page OCR step in `app/page.tsx` still uses hardcoded I-765 text, and the route handler does not pull document context from a database. That work belongs to the parallel Supabase workstream and will plug into the system prompt (or a tool call) once it lands.
- No conversation persistence yet; refreshing `/chat` resets to the seed thread.
- The seed messages and AI-generated suggestion chips / annotations / citations from the live model are still future work — those need structured-output generation grounded against a real document.