### PR TITLE
fix(upload): prevent timeout-induced "Unexpected token '<'" on Vercel

### DIFF
--- a/my-app/app/api/upload/route.ts
+++ b/my-app/app/api/upload/route.ts
@@ -7,6 +7,10 @@ import {
 import { extractUploadText } from "@/lib/extract-upload-text";
 
 export const runtime = "nodejs";
+// OCR (vision) + structured review-field generation can each take several seconds.
+// Vercel's default function timeout is 10s, which is not enough and causes the
+// platform to return an HTML error page (which the client cannot parse as JSON).
+export const maxDuration = 60;
 
 type LanguageCode = "en" | "es" | "zh" | "ar" | "fr";
 
@@ -156,9 +160,13 @@ export async function POST(req: Request) {
       language,
       reviewFields,
     });
-  } catch {
+  } catch (err) {
+    console.error("[upload] unexpected error:", err);
     return Response.json(
-      { error: "Unexpected upload processing error" },
+      {
+        error: "Unexpected upload processing error",
+        details: err instanceof Error ? err.message : String(err),
+      },
       { status: 500 },
     );
   }

--- a/my-app/app/step/1/page.tsx
+++ b/my-app/app/step/1/page.tsx
@@ -55,18 +55,31 @@ function UploadStepInner() {
         body: payload,
       });
 
-      const data = (await response.json()) as {
+      // Read as text first so HTML error pages (timeout/5xx from the platform)
+      // surface a real message instead of crashing JSON.parse.
+      const rawBody = await response.text();
+      let data: {
         documentId?: string;
         error?: string;
         details?: string;
         hint?: string;
-      };
+      } = {};
+      try {
+        data = rawBody ? JSON.parse(rawBody) : {};
+      } catch {
+        const snippet = rawBody.slice(0, 120).replace(/\s+/g, " ").trim();
+        throw new Error(
+          response.status === 504 || response.status === 408
+            ? "The upload took too long and was cancelled by the server. Please try a smaller file."
+            : `Server returned a non-JSON response (HTTP ${response.status}). ${snippet ? `Body starts with: ${snippet}` : ""}`,
+        );
+      }
 
       if (!response.ok || !data.documentId) {
         const message = [data.error, data.details, data.hint]
           .filter(Boolean)
           .join(". ");
-        throw new Error(message || "Upload failed");
+        throw new Error(message || `Upload failed (HTTP ${response.status})`);
       }
 
       router.push(


### PR DESCRIPTION
Set maxDuration=60 on /api/upload so OCR + AI review-field generation can finish within Vercel's serverless function limits (default 10s was killing the request and returning an HTML error page).

Also make the Step 1 client read the response as text and parse JSON defensively, so platform error pages surface a real message (e.g. timeout) instead of crashing JSON.parse, and log the underlying exception in the route so production failures are debuggable.